### PR TITLE
fixed the timeout-received handling

### DIFF
--- a/src/handlers/positions/handler.js
+++ b/src/handlers/positions/handler.js
@@ -142,41 +142,18 @@ const positions = async (error, messages) => {
         }
         await PositionService.changeParticipantPosition(transferInfo.participantCurrencyId, isIncrease, transferInfo.amount, transferStateChange)
       }
-    } else if (message.value.metadata.event.type === TransferEventType.POSITION && message.value.metadata.event.action === TransferEventAction.TIMEOUT_RECEIVED) {
-      Logger.info('PositionHandler::positions::timeoutPrepared')
-      const transferInfo = await TransferService.getTransferInfoToChangePosition(payload.transferId, Enum.TransferParticipantRoleType.PAYEE_DFSP, Enum.LedgerEntryType.PRINCIPLE_VALUE)
-      if (transferInfo.transferStateId !== TransferState.EXPIRED) {
-        Logger.info('PositionHandler::positions::commit::validationFailed::notReceivedFulfilState')
-        // TODO: throw Error 2001
-      } else { // transfer state check success
-        const isIncrease = false
-        const transferStateChange = {
-          transferId: transferInfo.transferId,
-          transferStateId: TransferState.ABORTED,
-          reason: 'Client requested to use a transfer that has already expired.'
-        }
-        await PositionService.changeParticipantPosition(transferInfo.participantCurrencyId, isIncrease, transferInfo.amount, transferStateChange)
-        let newMessage = Object.assign({}, message)
-        newMessage.value.content.payload = Utility.createPrepareErrorStatus(3303, 'Client requested to use a transfer that has already expired.', newMessage.value.content.payload.extensionList)
-        kafkaTopic = Utility.transformAccountToTopicName(newMessage.value.from, TransferEventType.POSITION, TransferEventAction.ABORT)
-        consumer = Kafka.Consumer.getConsumer(kafkaTopic)
-        // @mdebarros: I am not sure how this code ever worked in the develop branch?
-        // consumer = Kafka.Consumer.getConsumer(
-        //   await Utility.produceGeneralMessage(Utility.ENUMS.NOTIFICATION, Utility.ENUMS.EVENT, message.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, 4001, transferStateChange.reason))
-        // )
-        await Utility.produceGeneralMessage(Utility.ENUMS.NOTIFICATION, Utility.ENUMS.EVENT, newMessage.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, 4001, transferStateChange.reason))
-      }
     } else if (message.value.metadata.event.type === TransferEventType.POSITION && message.value.metadata.event.action === TransferEventAction.TIMEOUT_RESERVED) {
       Logger.info('PositionHandler::positions::timeout')
-      const transferInfo = await TransferService.getTransferInfoToChangePosition(payload.transferId, Enum.TransferParticipantRoleType.PAYEE_DFSP, Enum.LedgerEntryType.PRINCIPLE_VALUE)
-      if (transferInfo.transferStateId !== TransferState.EXPIRED) {
+      const transferInfo = await TransferService.getTransferInfoToChangePosition(payload.transferId, Enum.TransferParticipantRoleType.PAYER_DFSP, Enum.LedgerEntryType.PRINCIPLE_VALUE)
+      if (transferInfo.transferStateId !== TransferState.RESERVED_TIMEOUT) {
         Logger.info('PositionHandler::positions::commit::validationFailed::notReceivedFulfilState')
-        // TODO: throw Error 2001
+        // throw Error 2001
+        throw new Error('Internal server error')
       } else { // transfer state check success
         const isIncrease = false
         const transferStateChange = {
           transferId: transferInfo.transferId,
-          transferStateId: TransferState.ABORTED,
+          transferStateId: TransferState.EXPIRED_RESERVED,
           reason: 'Client requested to use a transfer that has already expired.'
         }
         await PositionService.changeParticipantPosition(transferInfo.participantCurrencyId, isIncrease, transferInfo.amount, transferStateChange)
@@ -184,11 +161,15 @@ const positions = async (error, messages) => {
         newMessage.value.content.payload = Utility.createPrepareErrorStatus(3303, 'Client requested to use a transfer that has already expired.', newMessage.value.content.payload.extensionList)
         kafkaTopic = Utility.transformAccountToTopicName(newMessage.value.from, TransferEventType.POSITION, TransferEventAction.ABORT)
         consumer = Kafka.Consumer.getConsumer(kafkaTopic)
+        if (!Kafka.Consumer.isConsumerAutoCommitEnabled(kafkaTopic)) {
+          await consumer.commitMessageSync(message)
+        }
         // @mdebarros: I am not sure how this code ever worked in the develop branch?
         // consumer = Kafka.Consumer.getConsumer(
         //   await Utility.produceGeneralMessage(Utility.ENUMS.NOTIFICATION, Utility.ENUMS.EVENT, message.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, 4001, transferStateChange.reason))
         // )
         await Utility.produceGeneralMessage(Utility.ENUMS.NOTIFICATION, Utility.ENUMS.EVENT, newMessage.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, 4001, transferStateChange.reason))
+        return true
       }
     } else if (message.value.metadata.event.type === TransferEventType.POSITION && message.value.metadata.event.action === TransferEventAction.FAIL) {
       Logger.info('PositionHandler::positions::fail')

--- a/src/handlers/timeouts/handler.js
+++ b/src/handlers/timeouts/handler.js
@@ -63,7 +63,7 @@ const timeout = async () => {
     let segmentId = timeoutSegment ? timeoutSegment.segmentId : 0
     const cleanup = await TimeoutService.cleanupTransferTimeout()
     const latestTransferStateChange = await TimeoutService.getLatestTransferStateChange()
-    let intervalMax = parseInt(latestTransferStateChange.transferStateChangeId) || 0
+    let intervalMax = latestTransferStateChange && parseInt(latestTransferStateChange.transferStateChangeId) || 0
     let result = await TimeoutService.timeoutExpireReserved(segmentId, intervalMin, intervalMax)
 
     if (!Array.isArray(result)) {
@@ -73,16 +73,18 @@ const timeout = async () => {
     for (let i = 0; i < result.length; i++) {
       message = {
         id: result[i].transferId,
-        from: result[i].payerParticipantId,
-        to: result[i].payeeParticipantId,
+        from: result[i].payerFsp,
+        to: result[i].payeeFsp,
         type: 'application/json',
-        headers: {
-          'Content-Type': 'application/json',
-          'Date': new Date().toISOString(),
-          'FSPIOP-Source': Enum.headers.FSPIOP.SWITCH,
-          'FSPIOP-Destination': result[i].payerFsp
+        content: {
+          headers: {
+            'Content-Type': 'application/json',
+            'Date': new Date().toISOString(),
+            'FSPIOP-Source': Enum.headers.FSPIOP.SWITCH,
+            'FSPIOP-Destination': result[i].payerFsp
+          },
+          payload: Utility.createPrepareErrorStatus(errorCodeInternal, errorDescriptionInternal)
         },
-        payload: Utility.createPrepareErrorStatus(errorCodeInternal, errorDescriptionInternal),
         metadata: {
           event: {}
         }

--- a/src/models/transfer/facade.js
+++ b/src/models/transfer/facade.js
@@ -449,9 +449,13 @@ const timeoutExpireReserved = async (segmentId, intervalMin, intervalMax) => {
       })
       .innerJoin('participantCurrency AS pc1', 'pc1.participantCurrencyId', 'tp1.participantCurrencyId')
       .innerJoin('participant AS p1', 'p1.participantId', 'pc1.participantId')
+
+      .innerJoin('participantCurrency AS pc2', 'pc2.participantCurrencyId', 'tp2.participantCurrencyId')
+      .innerJoin('participant AS p2', 'p2.participantId', 'pc2.participantId')
+
       .where('tt.expirationDate', '<', transactionTimestamp)
       .select('tt.*', 'tsc.transferStateId', 'tp1.participantCurrencyId AS payerParticipantId',
-        'p1.name AS payerFsp', 'tp2.participantCurrencyId AS payeeParticipantId')
+        'p1.name AS payerFsp', 'p2.name AS payeeFsp', 'tp2.participantCurrencyId AS payeeParticipantId')
     return result
   } catch (e) {
     throw e

--- a/testPI2/unit/handlers/positions/handler.test.js
+++ b/testPI2/unit/handlers/positions/handler.test.js
@@ -479,28 +479,28 @@ Test('Position handler', transferHandlerTest => {
     //   test.end()
     // })
 
-    positionsTest.test('Update transferStateChange in the database for TIMEOUT_RECEIVED when messages is an array', async (test) => {
-      try {
-        await Kafka.Consumer.createHandler(topicName, config, command)
-        Utility.transformGeneralTopicName.returns(topicName)
-        Utility.createPrepareErrorStatus.returns(topicName)
-        Utility.getKafkaConfig.returns(config)
-        TransferStateChange.saveTransferStateChange.resolves(true)
-        TransferService.getTransferInfoToChangePosition.resolves({transferStateId: 'EXPIRED'})
-        // messages[0].value.metadata.event.action = transferEventAction.TIMEOUT_RECEIVED
-        // const result = await allTransferHandlers.positions(null, messages)
-        let m = Object.assign({}, JSON.parse(JSON.stringify(messages[0])))
-        m.value.metadata.event.action = transferEventAction.TIMEOUT_RECEIVED
-        const result = await allTransferHandlers.positions(null, [m])
-        Logger.info(result)
-        test.equal(result, true)
-        test.end()
-      } catch (e) {
-        console.log('error thrown' + e)
-        test.fail('Error thrown' + e)
-        test.end()
-      }
-    })
+    // positionsTest.test('Update transferStateChange in the database for TIMEOUT_RECEIVED when messages is an array', async (test) => {
+    //   try {
+    //     await Kafka.Consumer.createHandler(topicName, config, command)
+    //     Utility.transformGeneralTopicName.returns(topicName)
+    //     Utility.createPrepareErrorStatus.returns(topicName)
+    //     Utility.getKafkaConfig.returns(config)
+    //     TransferStateChange.saveTransferStateChange.resolves(true)
+    //     TransferService.getTransferInfoToChangePosition.resolves({transferStateId: 'EXPIRED'})
+    //     // messages[0].value.metadata.event.action = transferEventAction.TIMEOUT_RECEIVED
+    //     // const result = await allTransferHandlers.positions(null, messages)
+    //     let m = Object.assign({}, JSON.parse(JSON.stringify(messages[0])))
+    //     m.value.metadata.event.action = transferEventAction.TIMEOUT_RECEIVED
+    //     const result = await allTransferHandlers.positions(null, [m])
+    //     Logger.info(result)
+    //     test.equal(result, true)
+    //     test.end()
+    //   } catch (e) {
+    //     console.log('error thrown' + e)
+    //     test.fail('Error thrown' + e)
+    //     test.end()
+    //   }
+    // })
 
     positionsTest.test('Update transferStateChange in the database for TIMEOUT_RESERVED when messages is an array', async (test) => {
       try {
@@ -509,7 +509,7 @@ Test('Position handler', transferHandlerTest => {
         Utility.createPrepareErrorStatus.returns(topicName)
         Utility.getKafkaConfig.returns(config)
         TransferStateChange.saveTransferStateChange.resolves(true)
-        TransferService.getTransferInfoToChangePosition.resolves({transferStateId: 'EXPIRED'})
+        TransferService.getTransferInfoToChangePosition.resolves({transferStateId: 'RESERVED_TIMEOUT'})
         /* messages[0].value.metadata.event.action = transferEventAction.TIMEOUT_RESERVED
         const result = await allTransferHandlers.positions(null, messages) */
         let m = Object.assign({}, JSON.parse(JSON.stringify(messages[0])))
@@ -521,6 +521,28 @@ Test('Position handler', transferHandlerTest => {
       } catch (e) {
         console.log('error thrown' + e)
         test.fail('Error thrown' + e)
+        test.end()
+      }
+    })
+
+    positionsTest.test('TIMEOUT_RESERVED should throw error if the transfer state is not RESERVED_TIMEOUT', async (test) => {
+      try {
+        await Kafka.Consumer.createHandler(topicName, config, command)
+        Utility.transformGeneralTopicName.returns(topicName)
+        Utility.createPrepareErrorStatus.returns(topicName)
+        Utility.getKafkaConfig.returns(config)
+        TransferStateChange.saveTransferStateChange.resolves(true)
+        TransferService.getTransferInfoToChangePosition.resolves({transferStateId: 'INVALID_STATE'})
+        /* messages[0].value.metadata.event.action = transferEventAction.TIMEOUT_RESERVED
+        const result = await allTransferHandlers.positions(null, messages) */
+        let m = Object.assign({}, JSON.parse(JSON.stringify(messages[0])))
+        m.value.metadata.event.action = transferEventAction.TIMEOUT_RESERVED
+        await allTransferHandlers.positions(null, [m])
+        test.fail('should throw')
+        test.end()
+      } catch (e) {
+        console.log('error thrown' + e)
+        test.pass('Error thrown' + e)
         test.end()
       }
     })


### PR DESCRIPTION
Hello Georgi,
This PR has following changes

1. Fixed below part

```
      message = {
        id: result[i].transferId,
        from: result[i].payerFsp,
        to: result[i].payeeFsp,

```
2. Fixed the unit tests
3. fixed the position handler to handle the timeouts correctly
4. added the unit/coverage test